### PR TITLE
fix: Pass api_key directly to LiveDataProvider

### DIFF
--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -348,9 +348,7 @@ def main():
                 # Fetch matches button
                 if st.button("🔄 Fetch Current Matches"):
                     from src.data.live_provider import LiveDataProvider
-                    import os
-                    os.environ["CRIC_API_KEY"] = api_key
-                    provider = LiveDataProvider()
+                    provider = LiveDataProvider(api_key=api_key)
                     matches = provider.get_current_matches()
                     if matches:
                         st.session_state['available_matches'] = matches

--- a/src/data/live_provider.py
+++ b/src/data/live_provider.py
@@ -16,10 +16,10 @@ class LiveDataProvider(BaseDataProvider):
     
     BASE_URL = "https://api.cricapi.com/v1"
     
-    def __init__(self):
-        self.api_key = os.getenv("CRIC_API_KEY")
+    def __init__(self, api_key: str = None):
+        self.api_key = api_key or os.getenv("CRIC_API_KEY")
         if not self.api_key:
-            print("⚠️ CRIC_API_KEY not found in env. Live data may fail.")
+            print("⚠️ CRIC_API_KEY not found. Live data may fail.")
             
     def _make_request(self, endpoint: str, params: Dict[str, Any] = None) -> Dict[str, Any]:
         """Helper to make API requests."""


### PR DESCRIPTION
Fixes AttributeError when fetching matches by passing api_key directly to constructor.