### PR TITLE
chore(config): ignore .cursorrules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ htmlcov/
 # Temp
 *.tmp
 *.temp
+
+# AI Workflow
+.cursorrules


### PR DESCRIPTION
## Summary
Added `.cursorrules` to `.gitignore` to prevent local workflow configuration derived from the AI agent from being tracked in the public repository. This ensures better separation of concerns between local dev environment tools and shared project code.

## Closes
Closes #78

## Testing
- [x] Unit tests passed (N/A - config change)
- [x] Manual verification (commands + output):
  > Ran `git status` locally:
  > `Untracked files: .cursorrules` (ignored)
  > `modified: .gitignore`
  > Verified `.cursorrules` is NO LONGER listed as untracked after modifying `.gitignore`.

## Risk/Rollback
Low risk. Revert commit to restore tracking if needed (though unlikely required).
